### PR TITLE
Remove feature flag

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,4 @@
 #![warn(missing_docs)]
-#![feature(destructuring_assignment)]
 
 //! This library provides algorithms and helper functions for constructing and comparing phylogenies.
 //!


### PR DESCRIPTION
Hi,

Thanks for making this package available. I have tried to use it in stable rust and got this error:

```
error[E0554]: `#![feature]` may not be used on the stable release channel                                                                                                                                                                                                
2 | #![feature(destructuring_assignment)]                                                                                                  
  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: remove the attribute                                                                       
  |                                                                                                                                        
  = help: the feature `destructuring_assignment` has been stable since `1.59.0` and no longer requires an attribute to enable  
```

This PR removes the feature flag as suggested by the compiler.